### PR TITLE
Add node 6.x version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+node_js:
+  - "6.1"
+  - "5.11"
 services:
   - mongodb
 cache:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "private": false,
   "engines": {
-    "node": "5.x.x",
+    "node": "5.11.x",
     "npm": "3.3.x"
   },
   "scripts": {


### PR DESCRIPTION
Run instructions for runing tests in both 5.11.x & 6.1.x node versions